### PR TITLE
Adapt to latest talos models, bulk exomiser results

### DIFF
--- a/Analyses/evaluation/talos_evaluation.py
+++ b/Analyses/evaluation/talos_evaluation.py
@@ -46,10 +46,12 @@ class Family(BaseModel):
     talos_results: list[ReportVariant] = Field(default_factory=list)
     _talos_phenotype_match_found: Optional[bool] = None
 
-    exomiser_results: Optional[dict] = None
-    solved_by_exomiser: Optional[bool] = None
+    exomiser_results: dict = {}
     exomiser_rank: Optional[int] = None
-    exomiser_results_exists: Optional[bool] = None
+
+    # will be overwritten if results are found
+    exomiser_results_exists: bool = False
+    solved_by_exomiser: bool = False
 
     in_scope_variant_types: set = VARIANT_TYPES_BASIC
     in_scope_mosaics: bool = False
@@ -91,9 +93,15 @@ class Family(BaseModel):
     @property
     def has_out_of_scope_variant_type(self):
         """Does this family have variants tyoes that are out of scope?"""
-        if self.variant1 and self.variant1.variant_type not in self.in_scope_variant_types:
+        if (
+            self.variant1
+            and self.variant1.variant_type not in self.in_scope_variant_types
+        ):
             return True
-        if self.variant2 and self.variant2.variant_type not in self.in_scope_variant_types:
+        if (
+            self.variant2
+            and self.variant2.variant_type not in self.in_scope_variant_types
+        ):
             return True
         return False
 
@@ -109,7 +117,11 @@ class Family(BaseModel):
             return self._talos_phenotype_match_found
 
         if self.variant1 and (talos_hit := self.variant1.talos_hit):
-            if talos_hit.phenotype_labels or talos_hit.panels.forced or talos_hit.panels.matched:
+            if (
+                talos_hit.phenotype_labels
+                or talos_hit.panels.forced
+                or talos_hit.panels.matched
+            ):
                 self._talos_phenotype_match_found = True
             else:
                 self._talos_phenotype_match_found = False
@@ -131,7 +143,11 @@ class Family(BaseModel):
             return None
 
         return len(
-            [r for r in self.talos_results.variants if r.phenotype_labels or r.panels.forced or r.panels.matched]
+            [
+                r
+                for r in self.talos_results.variants
+                if r.phenotype_labels or r.panels.forced or r.panels.matched
+            ]
         )
 
     @property
@@ -160,84 +176,96 @@ class Family(BaseModel):
     @property
     def variant_types(self):
         """Return a set of variant types that are causative in this family"""
-        return {x.variant_type for x in [self.variant1, self.variant2] if x and x.variant_type}
+        return {
+            x.variant_type
+            for x in [self.variant1, self.variant2]
+            if x and x.variant_type
+        }
 
-    def find_causitive_variants_in_talos_resuts(self):
-        """For each causitive variant, look for a matching variant in the talos candidate list
+    def find_causative_variants_in_talos_resuts(self):
+        """For each causative variant, look for a matching variant in the talos candidate list
 
-        sets talos_hit attribute on the causitive variant/s
+        sets talos_hit attribute on the causative variant/s
         """
         if self.talos_results and self.talos_results.variants:
             if self.variant1:
-                self.variant1.talos_hit = self.find_causitive_variant_in_talos(self.variant1)
+                self.variant1.talos_hit = self.find_causative_variant_in_talos(
+                    self.variant1
+                )
             if self.variant2:
-                self.variant2.talos_hit = self.find_causitive_variant_in_talos(self.variant2)
+                self.variant2.talos_hit = self.find_causative_variant_in_talos(
+                    self.variant2
+                )
 
-    def find_causitive_variant_in_talos(self, causitive_variant: CausativeVariant) -> Optional[ReportVariant]:
+    def find_causative_variant_in_talos(
+        self, causative_variant: CausativeVariant
+    ) -> Optional[ReportVariant]:
         """
-        For a given causitive variant, find a matching variant in the talos candidate list
+        For a given causative variant, find a matching variant in the talos candidate list
         """
         for r in self.talos_results.variants:
-            if r.var_data.coordinates.string_format == causitive_variant.variant_id:
+            if r.var_data.coordinates.string_format == causative_variant.variant_id:
                 return r
 
-            if causitive_variant.variant_type == "CNV_SV" and isinstance(r.var_data, StructuralVariant):
+            if causative_variant.variant_type == "CNV_SV" and isinstance(
+                r.var_data, StructuralVariant
+            ):
                 # CNV_SV match based on gene symbol in the predicted_lof field
-                if causitive_variant.gene in r.var_data.info["predicted_lof"].split(","):
+                if causative_variant.gene in r.var_data.info["predicted_lof"].split(
+                    ","
+                ):
                     return r
         return None
 
-    def find_exomiser_results(self, exomiser_dir: str) -> bool:
+    def find_exomiser_results(self, exomiser_results: dict) -> None:
         """
-        Look for an exomiser result result for this family. If found, find ranks of causitive variants
+        Look for an exomiser result for this family. If found, find ranks of causative variants
 
         If exomiser result file is found self.exomiser_results_exists is set to True
 
-        If the causitive variant/s are found in the exomiser results, the self.exomiser_rank
+        If the causative variant/s are found in the exomiser results, the self.exomiser_rank
         is set to the highest rank.
 
-        If only one causitive variant is found for an AR condition, the family is considered
+        If only one causative variant is found for an AR condition, the family is considered
         unsolved by exomiser and the rank is set to None
-
         """
 
-        exomiser_path = CloudPath(exomiser_dir) / f"{self.external_id}.variants.tsv"
+        # we don't get here unless we have exomiser results
+        self.exomiser_results_exists = True
+
         self.exomiser_results = {}
-        try:
-            exomiser_file = exomiser_path.open()
-            self.exomiser_results_exists = True
-        except FileNotFoundError:
-            self.exomiser_results_exists = False
-            return
 
-        for line in csv.DictReader(exomiser_file, delimiter="\t"):
-            trimmed_variant_id = line["ID"].split("_")[0]
+        # result blocks in this file look like
+        # "chr1:1234567:G:C": [
+        #     {
+        #         "rank": 1,
+        #         "moi": "AD"
+        #     },
+        #     {
+        #         "rank": 2,
+        #         "moi": "AR"
+        #     },
+        # ],
+        for key, values in exomiser_results.get(self.sample_id, {}).items():
+            new_key = key.replace("chr", "").replace(":", "-")
             # Variants can appear multiple times in the exomiser results (eg AD/AR)
-            # For this analyis we are only interested in presence/absense so we
+            # For this analysis we are only interested in presence/absense so we
             # will only keep the highest ranking variant
-            if trimmed_variant_id in self.exomiser_results:
-                continue
-            self.exomiser_results[trimmed_variant_id] = line
+            self.exomiser_results[new_key] = min([entry["rank"] for entry in values])
 
-        # Find the rank of the causitive variants in exomiser results
+        # Find the rank of the causative variants in exomiser results
         if self.variant1:
-            try:
-                self.variant1.exomiser_hit = self.exomiser_results[self.variant1.variant_id]
-                rank_1 = int(self.variant1.exomiser_hit["#RANK"])
-            except KeyError:
-                rank_1 = None
+            rank_1 = self.exomiser_results.get(self.variant1.variant_id)
+        else:
+            rank_1 = None
 
         if self.variant2:
-            try:
-                self.variant2.exomiser_hit = self.exomiser_results[self.variant2.variant_id]
-                rank_2 = int(self.variant2.exomiser_hit["#RANK"])
+            rank_2 = self.exomiser_results.get(self.variant2.variant_id)
+        else:
+            rank_2 = None
 
-            except KeyError:
-                rank_2 = None
-
-        # Set exomiser_rank if ALL causitive variants are found
+        # Set exomiser_rank if ALL causative variants are found
         # if two variants are found, use the highest rank
-        self.exomiser_rank = None
         self.solved_by_exomiser = False
         if self.variant1 and self.variant2:
             if rank_1 is not None and rank_2 is not None:
@@ -266,7 +294,10 @@ def parse_truth_data(
     for fam in csv.DictReader(CloudPath(truth_tsv_path).open(), delimiter="\t"):
         if fam["variant_1_type"]:
             v1 = CausativeVariant(
-                variant_id=fam["variant_1"].strip().removeprefix("chr").replace(":", "-"),
+                variant_id=fam["variant_1"]
+                .strip()
+                .removeprefix("chr")
+                .replace(":", "-"),
                 gene=fam["causative_gene"],
                 variant_type=fam["variant_1_type"],
                 variant_description=fam["variant_1_description"],
@@ -276,7 +307,10 @@ def parse_truth_data(
 
         if fam["variant_2_type"]:
             v2 = CausativeVariant(
-                variant_id=fam["variant_2"].strip().removeprefix("chr").replace(":", "-"),
+                variant_id=fam["variant_2"]
+                .strip()
+                .removeprefix("chr")
+                .replace(":", "-"),
                 gene=fam["causative_gene"],
                 variant_type=fam["variant_2_type"],
                 variant_description=fam["variant_2_description"],
@@ -305,13 +339,19 @@ def generate_summary_stats(families):
     solved_in_scope_families = len([f for f in families if f.solved_in_scope])
     solved_by_talos = len([f for f in families if f.solved_by_talos_and_in_scope])
     solved_by_talos_w_phen_match = len(
-        [f for f in families if f.solved_by_talos_and_in_scope and f.talos_phenotype_match_found]
+        [
+            f
+            for f in families
+            if f.solved_by_talos_and_in_scope and f.talos_phenotype_match_found
+        ]
     )
 
     pct_talos_solved_all = solved_by_talos / solved_families * 100
     pct_talos_solved_in_scope = solved_by_talos / solved_in_scope_families * 100
     pct_talos_solved_w_phen_match = solved_by_talos_w_phen_match / solved_families * 100
-    pct_talos_solved_w_phen_match_in_scope = solved_by_talos_w_phen_match / solved_in_scope_families * 100
+    pct_talos_solved_w_phen_match_in_scope = (
+        solved_by_talos_w_phen_match / solved_in_scope_families * 100
+    )
 
     summary_stats = f"""
         Total families: {total_families}
@@ -328,22 +368,44 @@ def generate_summary_stats(families):
     """
 
     # Exomiser stats
-    total_solved_and_run_exomiser = len([f for f in families if f.solved and f.solved_by_exomiser is not None])
+    total_solved_and_run_exomiser = len(
+        [f for f in families if f.solved and f.solved_by_exomiser is not None]
+    )
 
     # bail if exomiser results not provided
     if not total_solved_and_run_exomiser:
         return summary_stats, ""
 
     total_solved_and_run_exomiser_snv_only = len(
-        [f for f in families if f.solved and f.solved_by_exomiser is not None and f.variant_types == {"SNV_INDEL"}]
+        [
+            f
+            for f in families
+            if f.solved
+            and f.solved_by_exomiser is not None
+            and f.variant_types == {"SNV_INDEL"}
+        ]
     )
     solved_by_exomiser = len([f for f in families if f.solved_by_exomiser])
-    solved_by_exomiser_top1 = len([f for f in families if f.solved_by_exomiser and f.exomiser_rank == 1])
-    solved_by_exomiser_top5 = len([f for f in families if f.solved_by_exomiser and f.exomiser_rank <= 5])
-    solved_by_exomiser_top10 = len([f for f in families if f.solved_by_exomiser and f.exomiser_rank <= 10])
+    solved_by_exomiser_top1 = len(
+        [f for f in families if f.solved_by_exomiser and f.exomiser_rank == 1]
+    )
+    solved_by_exomiser_top5 = len(
+        [f for f in families if f.solved_by_exomiser and f.exomiser_rank <= 5]
+    )
+    solved_by_exomiser_top10 = len(
+        [f for f in families if f.solved_by_exomiser and f.exomiser_rank <= 10]
+    )
 
-    solved_by_exomiser_set = set([f.family_id for f in families if f.solved_by_exomiser])
-    solved_by_talos_set = set([f.family_id for f in families if f.solved_by_talos and f.solved_by_exomiser is not None])
+    solved_by_exomiser_set = set(
+        [f.family_id for f in families if f.solved_by_exomiser]
+    )
+    solved_by_talos_set = set(
+        [
+            f.family_id
+            for f in families
+            if f.solved_by_talos and f.solved_by_exomiser is not None
+        ]
+    )
 
     exomiser_summary = f"""
         Solved by exomiser: {solved_by_exomiser} ({solved_by_exomiser/total_solved_and_run_exomiser*100:.1f}%, {solved_by_exomiser/total_solved_and_run_exomiser_snv_only*100:.1f}% of SNV only)
@@ -430,8 +492,16 @@ def write_per_family_results(families, out_tsv):
                     [
                         x
                         for x in [
-                            family.variant1.variant_description if family.variant1 else None,
-                            family.variant2.variant_description if family.variant2 else None,
+                            (
+                                family.variant1.variant_description
+                                if family.variant1
+                                else None
+                            ),
+                            (
+                                family.variant2.variant_description
+                                if family.variant2
+                                else None
+                            ),
                         ]
                         if x
                     ]
@@ -449,7 +519,10 @@ def write_per_family_results(families, out_tsv):
 def cli_main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "in_scope_variants", help="Varint types to include in the evaluation", choices=["all", "core"], default="core"
+        "in_scope_variants",
+        help="Variant types to include in the evaluation",
+        choices=["all", "core"],
+        default="core",
     )
     parser.add_argument(
         "--incomplete_penetrance",
@@ -458,13 +531,26 @@ def cli_main():
         default=False,
     )
     parser.add_argument(
-        "--intergenic_in_scope", help="Consider intergenic variants as in scope", action="store_true", default=False
+        "--intergenic_in_scope",
+        help="Consider intergenic variants as in scope",
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
-        "--mosaic_in_scope", help="Consider mosaic variants as in scope", action="store_true", default=False
+        "--mosaic_in_scope",
+        help="Consider mosaic variants as in scope",
+        action="store_true",
+        default=False,
     )
-    parser.add_argument("--process_full_trios_only", help="process only trios", action="store_true", default=False)
-    parser.add_argument("--summary_tsv", help="Output path for summary tsv", type=argparse.FileType("w"))
+    parser.add_argument(
+        "--process_full_trios_only",
+        help="process only trios",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--summary_tsv", help="Output path for summary tsv", type=argparse.FileType("w")
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -498,14 +584,14 @@ def main(
     # Should pass this as a config file but...
     sub_cohorts = {
         "genome": {
-            "talos_results": "gs://cpg-acute-care-main/reanalysis/2024-12-10/pheno_annotated_report.json",
+            "talos_results": "gs://cpg-acute-care-main/reanalysis/2025-01-22/pheno_annotated_report.json",
             "truth_tsv_path": "gs://cpg-acute-care-main-upload/talos_truth_data/240829_acute_care-genome-gold_std.tsv",
-            "exomiser_results_dir": "gs://cpg-acute-care-main-analysis/exomiser_14_results",
+            "exomiser_results": "gs://cpg-acute-care-main-analysis/39c12fb9076d3e45a7b6a9c09aed7512dc2491_2405/exomiser_variant_results.json",
         },
         "exome": {
-            "talos_results": "gs://cpg-acute-care-main/exome/reanalysis/2024-12-10/pheno_annotated_report.json",
+            "talos_results": "gs://cpg-acute-care-main/exome/reanalysis/2025-01-22/pheno_annotated_report.json",
             "truth_tsv_path": "gs://cpg-acute-care-main-upload/talos_truth_data/240822_acute_care-exome-gold_std.tsv",
-            "exomiser_results_dir": "gs://cpg-acute-care-main-analysis/exome/exomiser_14_results",
+            "exomiser_results": "gs://cpg-acute-care-main-analysis/exome/d671000b77331661dd38ec58250671b6807863_342/exomiser_variant_results.json",
         },
         # "rgp": {
         #     "talos_results": "gs://cpg-broad-rgp-main-upload/talos_truth_data/pheno_annotated_report_2024_10_29.json",
@@ -516,7 +602,9 @@ def main(
     # Parse families from truth data
     families = []
     for subcohort_label, subcohort_dict in sub_cohorts.items():
-        talos_results_json = json.load(CloudPath(subcohort_dict["talos_results"]).open())
+        talos_results_json = json.load(
+            CloudPath(subcohort_dict["talos_results"]).open()
+        )
 
         sub_cohort_families = parse_truth_data(
             truth_tsv_path=subcohort_dict["truth_tsv_path"],
@@ -527,6 +615,13 @@ def main(
             in_scope_incomplete_penetrance=in_scope_incomplete_penetrance,
             in_scope_intergenic=in_scope_intergenic,
         )
+
+        # look for exomiser results
+        if exomiser_results_path := subcohort_dict.get("exomiser_results"):
+            # single aggregate of all exomiser results
+            exomiser_results = json.load(CloudPath(exomiser_results_path).open())
+        else:
+            exomiser_results = None
 
         # Annotate families with talos results
         for family in sub_cohort_families:
@@ -540,12 +635,14 @@ def main(
                 continue
 
             # Add talos results to family
-            family.talos_results = ParticipantResults.parse_obj(talos_results_json["results"][use_id])
-            family.find_causitive_variants_in_talos_resuts()
+            family.talos_results = ParticipantResults.model_validate(
+                talos_results_json["results"][use_id]
+            )
+            family.find_causative_variants_in_talos_resuts()
 
             # look for exomiser results
-            if "exomiser_results_dir" in subcohort_dict:
-                family.exomiser_results = family.find_exomiser_results(subcohort_dict["exomiser_results_dir"])
+            if exomiser_results is not None:
+                family.find_exomiser_results(exomiser_results)
 
         families.extend(sub_cohort_families)
 

--- a/Analyses/evaluation/talos_evaluation.py
+++ b/Analyses/evaluation/talos_evaluation.py
@@ -408,7 +408,7 @@ def generate_summary_stats(families):
 
     exomiser_summary = f"""
         Solved by exomiser: {solved_by_exomiser} ({solved_by_exomiser/total_solved_and_run_exomiser*100:.1f}%, {solved_by_exomiser/total_solved_and_run_exomiser_snv_only*100:.1f}% of SNV only)
-        Talos solved {len([f for f in families if f.solved_by_exomiser is not None and f.solved_by_talos])} of these ({len([f for f in families if f.solved_by_exomiser is not None and f.solved_by_talos and f.variant_types == set(["SNV_INDEL"]) ])} SNV only)
+        Talos solved {len([f for f in families if (f.solved_by_exomiser and f.solved_by_talos)])} of these ({len([f for f in families if f.solved_by_exomiser is not None and f.solved_by_talos and f.variant_types == set(["SNV_INDEL"]) ])} SNV only)
         Solved by exomiser (top 1): {solved_by_exomiser_top1} ({solved_by_exomiser_top1/total_solved_and_run_exomiser*100:.1f}%, {solved_by_exomiser_top1/total_solved_and_run_exomiser_snv_only*100:.1f}% of SNV only)
         Solved by exomiser (top 5): {solved_by_exomiser_top5} ({solved_by_exomiser_top5/total_solved_and_run_exomiser*100:.1f}%), {solved_by_exomiser_top5/total_solved_and_run_exomiser_snv_only*100:.1f}% of SNV only)
         Solved by exomiser (top 10): {solved_by_exomiser_top10} ({solved_by_exomiser_top10/total_solved_and_run_exomiser*100:.1f}%, {solved_by_exomiser_top10/total_solved_and_run_exomiser_snv_only*100:.1f}% of SNV only)

--- a/Analyses/evaluation/talos_evaluation.py
+++ b/Analyses/evaluation/talos_evaluation.py
@@ -368,7 +368,7 @@ def generate_summary_stats(families):
 
     # Exomiser stats
     total_solved_and_run_exomiser = len(
-        [f for f in families if f.solved and f.solved_by_exomiser is not None]
+        [f for f in families if f.solved and f.solved_by_exomiser]
     )
 
     # bail if exomiser results not provided
@@ -380,7 +380,7 @@ def generate_summary_stats(families):
             f
             for f in families
             if f.solved
-            and f.solved_by_exomiser is not None
+            and f.solved_by_exomiser
             and f.variant_types == {"SNV_INDEL"}
         ]
     )
@@ -402,7 +402,7 @@ def generate_summary_stats(families):
         [
             f.family_id
             for f in families
-            if f.solved_by_talos and f.solved_by_exomiser is not None
+            if f.solved_by_talos and f.solved_by_exomiser
         ]
     )
 

--- a/Analyses/evaluation/talos_evaluation.py
+++ b/Analyses/evaluation/talos_evaluation.py
@@ -230,9 +230,6 @@ class Family(BaseModel):
         unsolved by exomiser and the rank is set to None
         """
 
-        # we don't get here unless we have exomiser results
-        self.exomiser_results_exists = True
-
         self.exomiser_results = {}
 
         # result blocks in this file look like
@@ -253,6 +250,9 @@ class Family(BaseModel):
             # will only keep the highest ranking variant
             self.exomiser_results[new_key] = min([entry["rank"] for entry in values])
 
+        if self.exomiser_results:
+            self.exomiser_results_exists = True
+
         # Find the rank of the causative variants in exomiser results
         if self.variant1:
             rank_1 = self.exomiser_results.get(self.variant1.variant_id)
@@ -266,7 +266,6 @@ class Family(BaseModel):
 
         # Set exomiser_rank if ALL causative variants are found
         # if two variants are found, use the highest rank
-        self.solved_by_exomiser = False
         if self.variant1 and self.variant2:
             if rank_1 is not None and rank_2 is not None:
                 self.exomiser_rank = max(rank_1, rank_2)

--- a/Analyses/evaluation/talos_models.py
+++ b/Analyses/evaluation/talos_models.py
@@ -6,12 +6,12 @@ from pydantic import BaseModel, Field
 
 # Steal the talos models
 
-NON_HOM_CHROM = ['X', 'Y', 'MT', 'M']
+NON_HOM_CHROM = ["X", "Y", "MT", "M"]
 CHROM_ORDER = list(map(str, range(1, 23))) + NON_HOM_CHROM
 
 # some kind of version tracking
-CURRENT_VERSION = '1.1.0'
-ALL_VERSIONS = [None, '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.1.0']
+CURRENT_VERSION = "1.1.0"
+ALL_VERSIONS = [None, "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.1.0"]
 
 # ratios for use in AB testing
 MAX_WT = 0.15
@@ -19,7 +19,7 @@ MIN_HET = 0.25
 MAX_HET = 0.75
 MIN_HOM = 0.85
 _GRANULAR_DATE = None
-TIMEZONE = zoneinfo.ZoneInfo('Australia/Brisbane')
+TIMEZONE = zoneinfo.ZoneInfo("Australia/Brisbane")
 
 
 def get_granular_date():
@@ -28,20 +28,21 @@ def get_granular_date():
     """
     global _GRANULAR_DATE
     if _GRANULAR_DATE is None:
-        _GRANULAR_DATE = datetime.now(tz=TIMEZONE).strftime('%Y-%m-%d')
+        _GRANULAR_DATE = datetime.now(tz=TIMEZONE).strftime("%Y-%m-%d")
     return _GRANULAR_DATE
+
 
 class FileTypes(Enum):
     """
     enumeration of permitted input file types
     """
 
-    HAIL_TABLE = '.ht'
-    MATRIX_TABLE = '.mt'
-    PED = 'ped'
-    VCF = '.vcf'
-    VCF_GZ = '.vcf.gz'
-    VCF_BGZ = '.vcf.bgz'
+    HAIL_TABLE = ".ht"
+    MATRIX_TABLE = ".mt"
+    PED = "ped"
+    VCF = ".vcf"
+    VCF_GZ = ".vcf.gz"
+    VCF_BGZ = ".vcf.bgz"
 
 
 class PhenoPacketHpo(BaseModel):
@@ -68,7 +69,7 @@ class Coordinates(BaseModel):
         """
         forms a string representation: chr-pos-ref-alt
         """
-        return f'{self.chrom}-{self.pos}-{self.ref}-{self.alt}'
+        return f"{self.chrom}-{self.pos}-{self.ref}-{self.alt}"
 
     def __lt__(self, other) -> bool:
         """
@@ -92,7 +93,16 @@ class VariantCommon(BaseModel):
     """
 
     coordinates: Coordinates = Field(repr=True)
-    info: dict[str, str | int | float | list[str] | list[float] | dict[str, dict[str, int] | str | int] | bool] = Field(default_factory=dict)
+    info: dict[
+        str,
+        str
+        | int
+        | float
+        | list[str]
+        | list[float]
+        | dict[str, dict[str, int] | str | int]
+        | bool,
+    ] = Field(default_factory=dict)
     het_samples: set[str] = Field(default_factory=set, exclude=True)
     hom_samples: set[str] = Field(default_factory=set, exclude=True)
     boolean_categories: list[str] = Field(default_factory=list, exclude=True)
@@ -167,7 +177,9 @@ class VariantCommon(BaseModel):
         Returns:
             True if support only
         """
-        return self.has_support and not (self.category_non_support or self.sample_categorised_check(sample_id))
+        return self.has_support and not (
+            self.category_non_support or self.sample_categorised_check(sample_id)
+        )
 
     def category_values(self, sample: str) -> set[str]:
         """
@@ -186,16 +198,20 @@ class VariantCommon(BaseModel):
         for category in self.sample_categories:
             cat_samples = self.info[category]
             if not isinstance(cat_samples, list):
-                raise TypeError(f'Sample categories should be a list: {cat_samples}')
+                raise TypeError(f"Sample categories should be a list: {cat_samples}")
             if sample in cat_samples:
-                categories.add(category.removeprefix('categorysample'))
+                categories.add(category.removeprefix("categorysample"))
 
         categories.update(
-            {bool_cat.replace('categoryboolean', '') for bool_cat in self.boolean_categories if self.info[bool_cat]},
+            {
+                bool_cat.replace("categoryboolean", "")
+                for bool_cat in self.boolean_categories
+                if self.info[bool_cat]
+            },
         )
 
         if self.has_support:
-            categories.add('support')
+            categories.add("support")
 
         return categories
 
@@ -213,7 +229,7 @@ class VariantCommon(BaseModel):
         for category in self.sample_categories:
             cat_samples = self.info[category]
             assert isinstance(cat_samples, list)
-            if any(sam in cat_samples for sam in [sample_id, 'all']):
+            if any(sam in cat_samples for sam in [sample_id, "all"]):
                 return True
 
         return False
@@ -230,24 +246,32 @@ class VariantCommon(BaseModel):
         Returns:
             True if the variant is categorised for this sample
         """
-        big_cat = self.has_boolean_categories or self.sample_categorised_check(sample_id)
+        big_cat = self.has_boolean_categories or self.sample_categorised_check(
+            sample_id
+        )
         if allow_support:
             return big_cat or self.has_support
         return big_cat
 
-    def check_ab_ratio(self, *args, **kwargs) -> set[str]:  # noqa: ARG002, ANN002, ANN003
+    def check_ab_ratio(
+        self, *args, **kwargs
+    ) -> set[str]:  # noqa: ARG002, ANN002, ANN003
         """
         dummy method for AB ratio checking - not implemented for SVs
         """
         return set()
 
-    def get_sample_flags(self, *args, **kwargs) -> set[str]:  # noqa: ARG002, ANN002, ANN003
+    def get_sample_flags(
+        self, *args, **kwargs
+    ) -> set[str]:  # noqa: ARG002, ANN002, ANN003
         """
         dummy method for flag checking - not implemented for SVs (yet)
         """
         return set()
 
-    def check_read_depth(self, *args, **kwargs) -> set[str]:  # noqa: ARG002, ANN002, ANN003
+    def check_read_depth(
+        self, *args, **kwargs
+    ) -> set[str]:  # noqa: ARG002, ANN002, ANN003
         """
         dummy method for read depth checking - not implemented for SVs
         """
@@ -274,7 +298,9 @@ class SmallVariant(VariantCommon):
         """
         return self.check_ab_ratio(sample) | self.check_read_depth(sample)
 
-    def check_read_depth(self, sample: str, threshold: int = 10, var_is_cat_1: bool = False) -> set[str]:
+    def check_read_depth(
+        self, sample: str, threshold: int = 10, var_is_cat_1: bool = False
+    ) -> set[str]:
         """
         flag low read depth for this sample
 
@@ -287,7 +313,7 @@ class SmallVariant(VariantCommon):
             return a flag if this sample has low read depth
         """
         if self.depths[sample] < threshold and not var_is_cat_1:
-            return {'Low Read Depth'}
+            return {"Low Read Depth"}
         return set()
 
     def check_ab_ratio(self, sample: str) -> set[str]:
@@ -304,8 +330,12 @@ class SmallVariant(VariantCommon):
         hom = sample in self.hom_samples
         variant_ab = self.ab_ratios.get(sample, 0.0)
 
-        if (variant_ab <= MAX_WT) or (het and not MIN_HET <= variant_ab <= MAX_HET) or (hom and variant_ab <= MIN_HOM):
-            return {'AB Ratio'}
+        if (
+            (variant_ab <= MAX_WT)
+            or (het and not MIN_HET <= variant_ab <= MAX_HET)
+            or (hom and variant_ab <= MIN_HOM)
+        ):
+            return {"AB Ratio"}
         return set()
 
 
@@ -361,7 +391,10 @@ class ReportVariant(BaseModel):
         """
         makes reported variants comparable
         """
-        return self.sample == other.sample and self.var_data.coordinates == other.var_data.coordinates
+        return (
+            self.sample == other.sample
+            and self.var_data.coordinates == other.var_data.coordinates
+        )
 
     def __lt__(self, other):
         return self.var_data.coordinates < other.var_data.coordinates
@@ -388,7 +421,7 @@ class PanelShort(BaseModel):
 
     id: int
     name: str = Field(default_factory=str)
-    version: str = 'UNKNOWN'
+    version: str = "UNKNOWN"
 
 
 class PanelApp(BaseModel):
@@ -414,7 +447,7 @@ class HistoricSampleVariant(BaseModel):
     first_tagged: str
     support_vars: set[str] = Field(
         default_factory=set,
-        description='supporting variants if this has been identified in a comp-het',
+        description="supporting variants if this has been identified in a comp-het",
     )
     independent: bool = Field(default=True)
     clinvar_stars: int | None = None
@@ -451,9 +484,9 @@ class ResultMeta(BaseModel):
 
 
 class MemberSex(Enum):
-    MALE = 'male'
-    FEMALE = 'female'
-    UNKNOWN = 'unknown'
+    MALE = "male"
+    FEMALE = "female"
+    UNKNOWN = "unknown"
 
 
 class FamilyMembers(BaseModel):
@@ -535,7 +568,7 @@ class PedigreeMember(BaseModel):
     father: str | None = None
     sex: str
     affected: str
-    ext_id: str = 'Missing'
+    ext_id: str = "Missing"
     hpo_terms: list[PhenoPacketHpo] = Field(default_factory=list)
 
 

--- a/Analyses/evaluation/talos_models.py
+++ b/Analyses/evaluation/talos_models.py
@@ -92,7 +92,7 @@ class VariantCommon(BaseModel):
     """
 
     coordinates: Coordinates = Field(repr=True)
-    info: dict[str, str | int | float | list[str] | list[float] | dict[str, str] | bool] = Field(default_factory=dict)
+    info: dict[str, str | int | float | list[str] | list[float] | dict[str, dict[str, int] | str | int] | bool] = Field(default_factory=dict)
     het_samples: set[str] = Field(default_factory=set, exclude=True)
     hom_samples: set[str] = Field(default_factory=set, exclude=True)
     boolean_categories: list[str] = Field(default_factory=list, exclude=True)
@@ -354,6 +354,8 @@ class ReportVariant(BaseModel):
     support_vars: set[str] = Field(default_factory=set)
     # log whether there was an increase in ClinVar star rating since the last run
     clinvar_increase: bool = Field(default=False)
+    # exomiser results - I'd like to store this in a cleaner way in future
+    exomiser_results: list[str] = Field(default_factory=list)
 
     def __eq__(self, other):
         """


### PR DESCRIPTION
We now aggregate the whole cohort's exomiser results into a single file, use that instead of the per-family access (slow in GCP)

This adjusts to that file format which contains a hierarchical dict:

```
"sample_id": {
  "variant_id": {
    [
      {                   
        "rank": 1,
        "moi": "AD",
      },                  
        "rank": 2,
        "moi": "AR",
      },
    ]
  }
}
``` 

The models are updated to reflect the latest pydantic changes in Talos, required to pull in the latest result sets, and paths to those results are now the default hard-coded.

I've also run black and ruff on it just for consistency, so a chunk of non-functional line changes.